### PR TITLE
Add comprehensive SixtyFour API tutorial notebooks

### DIFF
--- a/sixtyfour_enrich_company_tutorial.ipynb
+++ b/sixtyfour_enrich_company_tutorial.ipynb
@@ -1,0 +1,348 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "0d397248",
+      "metadata": {
+        "id": "0d397248"
+      },
+      "source": [
+        "\n",
+        "# SixtyFour AI — Enrich Company\n",
+        "\n",
+        "This notebook is your guide to using the Sixtyfour API `enrich-company`.\n",
+        "\n",
+        "The `enrich-company` endpoint allows you to perform deep research on a company. It recursively reads through relevant sources (websites, profiles, public signals, socials) and can answer questions like: **Who owns this company?** **What is their approximate team size?** **What social accounts do they operate?** **What is their tech stack?** **Which decision-makers should I contact?**\n",
+        "\n",
+        "**Tip:** You can change the company in the parameters at the top. For best results, include at least the **company name** and **website** or a strong identifier (e.g., domain).\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e38f0379",
+      "metadata": {
+        "id": "e38f0379"
+      },
+      "source": [
+        "\n",
+        "## Prerequisites & Secrets\n",
+        "\n",
+        "### Get your SixtyFour API key\n",
+        "Follow these steps to create and copy your API key:\n",
+        "\n",
+        "**1) Sign in**  \n",
+        "Go to https://app.sixtyfour.ai/login and log in or sign up.\n",
+        "\n",
+        "**2)** Enter an organization name once you've signed up and click **Create Organization** and get your $25 in credits.\n",
+        "\n",
+        "**3)** You’ll land on the dashboard/usage page with credits. In the left sidebar, open **Keys** → click **Create new key** → name it → **Create key** → copy the key value.\n",
+        "\n",
+        "### If you’re in Google Colab\n",
+        "- Click the 🔑 (Secrets) icon in the left sidebar.  \n",
+        "- Add a secret named `SIXTYFOUR_API_KEY` and paste your key.  \n",
+        "- Make sure the notebook can access the secret.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "0334e42a",
+      "metadata": {
+        "id": "0334e42a",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "e80925cd-14fd-4ce1-bb10-f97a4e6878f4"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ Setup complete (key detected, endpoint ready).\n"
+          ]
+        }
+      ],
+      "source": [
+        "\n",
+        "# --- Parameters (you can change these) ---\n",
+        "COMPANY_NAME = \"Sixtyfour AI\"\n",
+        "COMPANY_WEBSITE = \"sixtyfour.ai\"\n",
+        "# COMPANY_ADDRESS = \"fill this in for better context\"\n",
+        "# COMPANY_PHONE = \"fill this in for better context\"\n",
+        "\n",
+        "# Optional controls\n",
+        "FIND_PEOPLE = True\n",
+        "\n",
+        "import os, json, requests\n",
+        "\n",
+        "API_KEY = os.getenv(\"SIXTYFOUR_API_KEY\", \"\")  # fallback if already set locally\n",
+        "try:\n",
+        "    from google.colab import userdata\n",
+        "    secret_val = userdata.get(\"SIXTYFOUR_API_KEY\")  # raises if not granted/not created\n",
+        "    if secret_val:\n",
+        "        os.environ[\"SIXTYFOUR_API_KEY\"] = secret_val\n",
+        "        API_KEY = secret_val\n",
+        "except Exception:\n",
+        "    pass  # Not in Colab or secret not available; rely on existing env var\n",
+        "\n",
+        "BASE_URL = \"https://api.sixtyfour.ai\"\n",
+        "SYNC_ENDPOINT = f\"{BASE_URL}/enrich-company\"\n",
+        "TIMEOUT_S = 600\n",
+        "\n",
+        "print(\"✅ Setup complete (key detected, endpoint ready).\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1b8a3c93",
+      "metadata": {
+        "id": "1b8a3c93"
+      },
+      "source": [
+        "\n",
+        "## Enrich_Company Request\n",
+        "\n",
+        "For most use cases, `enrich-company` is the perfect tool. You send a request and get enriched company data back with a single call.\n",
+        "\n",
+        "The request body requires two main components:\n",
+        "\n",
+        "- **target_company**: The initial data you have on the company. The more context you provide, the more focused and correct the research will be (e.g., name + website + address + phone).\n",
+        "- **struct**: The fields you want extracted. The key is the field name you want returned; the value is either a description string or an object with description and an optional type to guide the agent.\n",
+        "\n",
+        "Responses may take between 5-10 minutes depending on how deep the research goes.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "c164f3a8",
+      "metadata": {
+        "id": "c164f3a8",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "a575af1d-f8a4-4bae-91cd-e2b7109799c3"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ Success! Top-level keys: ['notes', 'structured_data', 'findings', 'references', 'confidence_score']\n",
+            "\n",
+            "Structured data:\n",
+            "{\n",
+            "  \"instagram_url\": \"\",\n",
+            "  \"is_remote_friendly\": \"\",\n",
+            "  \"hq_location\": \"San Francisco, California, United States\",\n",
+            "  \"linkedin_url\": \"https://www.linkedin.com/company/sixtyfourai\",\n",
+            "  \"num_employees\": 3,\n",
+            "  \"founded_year\": 2025,\n",
+            "  \"tech_stack\": \"Python, FastAPI, Docker, Machine Learning APIs, AI-driven API services\",\n",
+            "  \"revenue_estimate\": \"\",\n",
+            "  \"company_name\": \"Sixtyfour AI\",\n",
+            "  \"website\": \"https://sixtyfour.ai\",\n",
+            "  \"leads\": [\n",
+            "    {\n",
+            "      \"name\": \"Saarth Shah\",\n",
+            "      \"email\": \"saarth@sixtyfour.ai\",\n",
+            "      \"company\": \"Sixtyfour AI\",\n",
+            "      \"title\": \"CEO & Co-Founder\",\n",
+            "      \"phone\": \"\",\n",
+            "      \"score\": \"9.5\",\n",
+            "      \"linkedin\": \"https://www.linkedin.com/in/saarthshah\"\n",
+            "    },\n",
+            "    {\n",
+            "      \"name\": \"Christopher Price\",\n",
+            "      \"email\": \"\",\n",
+            "      \"company\": \"Sixtyfour AI\",\n",
+            "      \"title\": \"Founder / COO\",\n",
+            "      \"phone\": \"\",\n",
+            "      \"score\": \"9\",\n",
+            "      \"linkedin\": \"https://www.linkedin.com/in/christopher-price-59a24b178\"\n",
+            "    },\n",
+            "    {\n",
+            "      \"name\": \"Roham Mehrabi\",\n",
+            "      \"email\": \"\",\n",
+            "      \"company\": \"Sixtyfour AI\",\n",
+            "      \"title\": \"Forward Deployed Engineer\",\n",
+            "      \"phone\": \"\",\n",
+            "      \"score\": \"7\",\n",
+            "      \"linkedin\": \"https://www.linkedin.com/in/rxhxm\"\n",
+            "    }\n",
+            "  ]\n",
+            "}\n"
+          ]
+        }
+      ],
+      "source": [
+        "\n",
+        "target_company = {\n",
+        "    \"company_name\": COMPANY_NAME,\n",
+        "    \"website\": COMPANY_WEBSITE,\n",
+        "    # \"address\": COMPANY_ADDRESS,\n",
+        "    # \"phone_number\": COMPANY_PHONE,\n",
+        "}\n",
+        "\n",
+        "# You can optionally specify types for predictable outputs (e.g., {\"type\": \"int\"}); otherwise simple descriptions are fine.\n",
+        "# Below mixes untyped (plain descriptions) and typed (with {\"type\": ...}) fields.\n",
+        "struct = {\n",
+        "    \"instagram_url\": \"Instagram url for the photography company\",\n",
+        "    \"is_remote_friendly\": \"Is the company remote-friendly?\",\n",
+        "    \"hq_location\": \"HQ location (city, region, country)\",\n",
+        "    \"linkedin_url\": \"LinkedIn company page\",\n",
+        "\n",
+        "    # Typed structures\n",
+        "    \"num_employees\": {\"description\": \"Approximate number of employees\", \"type\": \"int\"},\n",
+        "    \"founded_year\": {\"description\": \"Year the company was founded\", \"type\": \"int\"},\n",
+        "    \"tech_stack\": {\"description\": \"Core technologies used\", \"type\": \"list[string]\"},\n",
+        "    \"revenue_estimate\": {\"description\": \"Estimated annual revenue\", \"type\": \"string\"}\n",
+        "    # You can also add your own fields here to find more information about the company.\n",
+        "\n",
+        "}\n",
+        "\n",
+        "payload = {\n",
+        "    \"target_company\": target_company,\n",
+        "    \"struct\": struct,\n",
+        "    \"find_people\": FIND_PEOPLE,\n",
+        "}\n",
+        "\n",
+        "resp = requests.post(\n",
+        "    SYNC_ENDPOINT,\n",
+        "    headers={\"x-api-key\": API_KEY, \"Content-Type\": \"application/json\"},\n",
+        "    json=payload,\n",
+        "    timeout=TIMEOUT_S,\n",
+        ")\n",
+        "\n",
+        "if resp.ok:\n",
+        "    data = resp.json()\n",
+        "    print(\"✅ Success! Top-level keys:\", list(data.keys()))\n",
+        "    print(\"\\nStructured data:\")\n",
+        "    print(json.dumps(data.get(\"structured_data\", {}), indent=2))\n",
+        "else:\n",
+        "    print(\"❌ Request failed:\", resp.status_code, resp.text[:800])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8bab0d73",
+      "metadata": {
+        "id": "8bab0d73"
+      },
+      "source": [
+        "\n",
+        "### How to change values\n",
+        "\n",
+        "- **Pick a different company:** edit `COMPANY_NAME` and `COMPANY_WEBSITE` (address/phone optional).  \n",
+        "- **Ask for different fields:** edit `struct`. Mix untyped (description strings) and typed objects with `description` and `type` if you need specific formats.  "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0f208814",
+      "metadata": {
+        "id": "0f208814"
+      },
+      "source": [
+        "\n",
+        "## Example structs you can run (copy/paste)\n",
+        "Pick one of these, assign to `struct`, then call the same `requests.post` as above.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "c838ea32",
+      "metadata": {
+        "id": "c838ea32"
+      },
+      "outputs": [],
+      "source": [
+        "\n",
+        "# Product/Engineering mapping\n",
+        "example_tech_struct = {\n",
+        "    \"company_name\": \"Official company name\",\n",
+        "    \"domain\": {\"description\": \"Primary domain (e.g., example.com)\", \"type\": \"string\"},\n",
+        "    \"tech_stack\": {\"description\": \"Key technologies used\", \"type\": \"list[string]\"},\n",
+        "    \"engineering_team_size\": {\"description\": \"Approximate size of engineering org\", \"type\": \"int\"},\n",
+        "    \"github_org\": {\"description\": \"Company GitHub org URL\", \"type\": \"string\"},\n",
+        "    \"notable_repos\": {\"description\": \"Top repositories (names/links)\", \"type\": \"list[string]\"}\n",
+        "}\n",
+        "\n",
+        "# Sales prospecting (company-level)\n",
+        "example_sales_struct = {\n",
+        "    \"company_name\": \"Official company name\",\n",
+        "    \"website\": \"Website URL\",\n",
+        "    \"num_employees\": {\"description\": \"Approximate employee count\", \"type\": \"int\"},\n",
+        "    \"hq_location\": {\"description\": \"Headquarters (city, region, country)\", \"type\": \"string\"},\n",
+        "    \"industry\": {\"description\": \"Primary industry/sector\", \"type\": \"string\"},\n",
+        "    \"recent_news\": {\"description\": \"Recent press or announcements\", \"type\": \"list[string]\"},\n",
+        "    \"key_buyers\": {\"description\": \"Buyer functions to target (e.g., Ops, RevOps)\", \"type\": \"list[string]\"}\n",
+        "}\n",
+        "\n",
+        "# Marketing\n",
+        "example_marketing_struct = {\n",
+        "    \"brand_handles\": {\"description\": \"Social profiles (Twitter, Instagram, LinkedIn)\", \"type\": \"list[string]\"},\n",
+        "    \"content_topics\": {\"description\": \"Topics they post about\", \"type\": \"list[string]\"},\n",
+        "    \"audience_size\": {\"description\": \"Aggregate audience size estimate\", \"type\": \"int\"},\n",
+        "    \"newsletter_url\": {\"description\": \"Newsletter or blog URL\", \"type\": \"string\"},\n",
+        "    \"paid_channels\": {\"description\": \"Paid marketing channels used\", \"type\": \"list[string]\"}\n",
+        "}\n",
+        "\n",
+        "# Partnerships / BD\n",
+        "example_bd_struct = {\n",
+        "    \"strategic_initiatives\": {\"description\": \"Key initiatives they own\", \"type\": \"list[string]\"},\n",
+        "    \"notable_customers\": {\"description\": \"Notable customers/logos\", \"type\": \"list[string]\"},\n",
+        "    \"ecosystem_partners\": {\"description\": \"Ecosystem/integration partners\", \"type\": \"list[string]\"},\n",
+        "    \"regions\": {\"description\": \"Regions the company operates in\", \"type\": \"list[string]\"}\n",
+        "}\n",
+        "\n",
+        "# Investor / diligence\n",
+        "example_investor_struct = {\n",
+        "    \"founded_year\": {\"description\": \"Year founded\", \"type\": \"int\"},\n",
+        "    \"founders\": {\"description\": \"Founders' names\", \"type\": \"list[string]\"},\n",
+        "    \"funding_rounds\": {\"description\": \"Funding rounds and amounts\", \"type\": \"list[string]\"},\n",
+        "    \"lead_investors\": {\"description\": \"Lead investors by round\", \"type\": \"list[string]\"},\n",
+        "    \"revenue_estimate\": {\"description\": \"Estimated revenue (latest FY)\", \"type\": \"string\"},\n",
+        "    \"num_employees\": {\"description\": \"Approximate employee count\", \"type\": \"int\"}\n",
+        "}\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\n",
+        "## Troubleshooting & Next steps\n",
+        "\n",
+        "**Remember:**  \n",
+        "- You can request up to 100 fields in one `struct`  \n",
+        "- Adding more fields doesn't increase API usage but adding rows does.\n",
+        "- Rate limit: **500 requests per minute** per API key  \n",
+        "- Don't be vague — “Sixtyfour” vs “Sixtyfour AI (YC X25) from SF”  \n",
+        "- Provide context — More details = better results  \n",
+        "\n",
+        "\n",
+        "**Next steps:** try a different `struct`, point the CSV output to your CRM, or move this into an automated script.\n"
+      ],
+      "metadata": {
+        "id": "ea00LedqvHUw"
+      },
+      "id": "ea00LedqvHUw"
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/sixtyfour_enrich_lead_tutorial.ipynb
+++ b/sixtyfour_enrich_lead_tutorial.ipynb
@@ -1,0 +1,362 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "9ee0f800",
+      "metadata": {
+        "id": "9ee0f800"
+      },
+      "source": [
+        "\n",
+        "# SixtyFour AI — Enrich Lead\n",
+        "\n",
+        "This notebook is your guide to using the **Sixtyfour API `enrich-lead`**. The enrich_lead endpoint allows you to perform deep research on an individual—be it a prospect, candidate, or contact.\n",
+        "\n",
+        "Enrich-Lead recrusively reads through every link and with this knowledge it can answer questions like: What is this individual an expert in? How many publications do they have? Are they a fashion reseller? Do they have experience with M&A transactions? Etc.\n",
+        "\n",
+        "Anything that you can think of is fair game for our API. Please give it a go, and let us know how we can help!\n",
+        "\n",
+        "> **Tip:** You can change the person in the parameters at the top. It can be **anyone with a digital presence**. For best results, include **at least**: `name` **and** `company`, or a direct identifier like `email` **or** `linkedin`.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c042bb69",
+      "metadata": {
+        "id": "c042bb69"
+      },
+      "source": [
+        "\n",
+        "## Prerequisites & Secrets\n",
+        "\n",
+        "### Get your SixtyFour API key\n",
+        "\n",
+        "Follow these steps to create and copy your API key\n",
+        "\n",
+        "**1) Sign in**\n",
+        "Go to <https://app.sixtyfour.ai/login> and log in or sign up.\n",
+        "\n",
+        "**2)** Enter an organization name once you've signed up and click **Create Organization**.\n",
+        "\n",
+        "**3)** You’ll land on the dashboard/usage page with $25 in credits. In the left sidebar, open **Keys** → click **Create new key** → name it → **Create key** → copy the key value.\n",
+        "\n",
+        "\n",
+        "\n",
+        "### If you’re in **Google Colab**\n",
+        "1. Click the **🔑 (Secrets)** icon in the left sidebar.  \n",
+        "2. Add a secret named `SIXTYFOUR_API_KEY` and paste your key.  \n",
+        "3. Make sure the notebook can access the secret.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "504736fe",
+      "metadata": {
+        "id": "504736fe"
+      },
+      "outputs": [],
+      "source": [
+        "\n",
+        "# --- Parameters (you can change these) ---\n",
+        "# Only name+company/university OR linkedin is needed\n",
+        "# You can also give the agent more context following the structure below\n",
+        "LEAD_NAME = \"Saarth Shah\"\n",
+        "LEAD_COMPANY = \"Sixtyfour AI\"\n",
+        "LEAD_EMAIL = None\n",
+        "LEAD_LINKEDIN = None\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "889a0d58",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "889a0d58",
+        "outputId": "236dab6b-0c99-492c-ac78-8469fdd530e5"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ Setup complete (key detected, endpoints ready).\n"
+          ]
+        }
+      ],
+      "source": [
+        "\n",
+        "import os, json, time, csv, io\n",
+        "from datetime import datetime\n",
+        "from typing import Dict, Any, List, Optional\n",
+        "\n",
+        "import requests\n",
+        "import pandas as pd\n",
+        "\n",
+        "API_KEY = os.getenv(\"SIXTYFOUR_API_KEY\", \"\")  # fallback if already set locally\n",
+        "try:\n",
+        "    from google.colab import userdata\n",
+        "    secret_val = userdata.get(\"SIXTYFOUR_API_KEY\")  # raises if not granted or not created\n",
+        "    if secret_val:  # avoid overwriting with empty\n",
+        "        os.environ[\"SIXTYFOUR_API_KEY\"] = secret_val\n",
+        "        API_KEY = secret_val\n",
+        "except Exception:\n",
+        "    # Not in Colab or secret not available; rely on existing env var\n",
+        "    pass\n",
+        "\n",
+        "BASE_URL = \"https://api.sixtyfour.ai\"\n",
+        "SYNC_ENDPOINT = f\"{BASE_URL}/enrich-lead\"\n",
+        "ASYNC_ENDPOINT = f\"{BASE_URL}/enrich-lead-async\"\n",
+        "STATUS_ENDPOINT = f\"{BASE_URL}/job-status\"\n",
+        "TIMEOUT_S = 600  # We reuse these endpoints and TIMEOUT_S throughout the notebook.\n",
+        "\n",
+        "print(\"✅ Setup complete (key detected, endpoints ready).\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "880ca739",
+      "metadata": {
+        "id": "880ca739"
+      },
+      "source": [
+        "## Enrich_Lead Request\n",
+        "\n",
+        "For most queries, enrich_lead is the perfect tool. You send a request and get a complete profile back with a single call.\n",
+        "\n",
+        "The request requires two main components in its body:\n",
+        "\n",
+        "* **`lead_info`**: The initial data you have on the person. The more context you provide, the more focused and correct the research will be.\n",
+        "* **`struct`**: Here is where you can request the niche pieces of information you'd like. The first part \"name\" is the field you want filled. The second part following the \":\" is the description given to the agent to help fulfill your exact request.\n",
+        "\n",
+        "Feel free to change structure in \"struct\" to something more relevant to you!\n",
+        "\n",
+        "**WARNING**  Please expect a four to five minute wait time for your response! We are working on latentcy, but the agent is actively reading everything live, which take a while"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "47206606",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "47206606",
+        "outputId": "d0dec945-8729-4414-bca9-a9cc21afb8ac"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ Success! Top-level keys: ['notes', 'structured_data', 'findings', 'references', 'confidence_score']\n",
+            "\n",
+            "Structured data:\n",
+            "{\n",
+            "  \"name\": \"Saarth Shah\",\n",
+            "  \"email\": \"saarth@sixtyfour.ai\",\n",
+            "  \"linkedin\": \"https://www.linkedin.com/in/saarthshah/\",\n",
+            "  \"location\": \"San Francisco Bay Area, California, United States\",\n",
+            "  \"title\": \"Co-founder and CEO\",\n",
+            "  \"company_size\": \"10-50 (estimated)\",\n",
+            "  \"industry\": \"Artificial Intelligence / Sales technology (SaaS)\",\n",
+            "  \"twitter_url\": \"https://x.com/saarth_\",\n",
+            "  \"github_url\": \"https://github.com/SaarthShah\",\n",
+            "  \"previous_companies\": \"['Whatnot', 'Deepgram', 'Internalize']\",\n",
+            "  \"years_experience\": 8,\n",
+            "  \"is_executive\": true,\n",
+            "  \"company\": \"Sixtyfour AI\"\n",
+            "}\n"
+          ]
+        }
+      ],
+      "source": [
+        "\n",
+        "lead_info = {\n",
+        "    \"name\": LEAD_NAME,\n",
+        "    \"company\": LEAD_COMPANY,\n",
+        "    # \"email\": LEAD_EMAIL,        # ← uncomment if you provided it above\n",
+        "    # \"linkedin\": LEAD_LINKEDIN,  # ← uncomment if you provided it above\n",
+        "}\n",
+        "\n",
+        "# Ask the API for a few fields; uncomment or add more if you want to find additional data.\n",
+        "struct = {\n",
+        "    \"name\": \"The individual's full name\",\n",
+        "    \"email\": {\"description\": \"Work email\", \"type\": \"string\"},\n",
+        "    \"linkedin\": \"LinkedIn URL\",\n",
+        "    \"location\": \"Location (city, region, country)\",\n",
+        "    \"title\": \"Current job title\",\n",
+        "    \"company_size\": \"Company size (employees)\",\n",
+        "    \"industry\": \"Industry of the company\",\n",
+        "    \"twitter_url\": \"Twitter profile URL\",\n",
+        "    \"github_url\": \"GitHub profile URL\",\n",
+        "    # You can also add your own fields here to find more information about the lead.\n",
+        "\n",
+        "\n",
+        "    # You can ask for typed fields (predictable format). Types (int, boolean, list[string], etc) make downstream code easier.\n",
+        "    \"email\": {\"description\": \"Work email\", \"type\": \"string\"},\n",
+        "    \"previous_companies\": {\"description\": \"Previous employers\", \"type\": \"list[string]\"},\n",
+        "    \"years_experience\": {\"description\": \"Total years\", \"type\": \"int\"},\n",
+        "    \"is_executive\": {\"description\": \"Is executive role\", \"type\": \"boolean\"}\n",
+        "}\n",
+        "\n",
+        "# This is the core API call to enrich a lead.\n",
+        "resp = requests.post(\n",
+        "    SYNC_ENDPOINT,\n",
+        "    headers={\"x-api-key\": API_KEY, \"Content-Type\": \"application/json\"},\n",
+        "    json={\"lead_info\": lead_info, \"struct\": struct},\n",
+        "    timeout=TIMEOUT_S\n",
+        ")\n",
+        "\n",
+        "if resp.ok:\n",
+        "    data = resp.json()\n",
+        "    print(\"✅ Success! Top-level keys:\", list(data.keys()))\n",
+        "    print(\"\\nStructured data:\")\n",
+        "    print(json.dumps(data.get(\"structured_data\", {}), indent=2))\n",
+        "else:\n",
+        "    print(\"❌ Request failed:\", resp.status_code, resp.text[:500])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "62b41ec6",
+      "metadata": {
+        "id": "62b41ec6"
+      },
+      "source": [
+        "\n",
+        "## Example structs you can run (copy/paste)\n",
+        "\n",
+        "Pick one of these, assign to `struct`, and make the same `requests.post` call as above.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "da940f05",
+      "metadata": {
+        "id": "da940f05"
+      },
+      "outputs": [],
+      "source": [
+        "\n",
+        "# Sales prospecting\n",
+        "example_sales_struct = {\n",
+        "    \"full_name\": \"Full name\",\n",
+        "    \"title\": \"Current job title\",\n",
+        "    \"email\": \"Professional email\",\n",
+        "    \"phone\": \"Phone number\",\n",
+        "    \"linkedin\": \"LinkedIn URL\",\n",
+        "    \"decision_authority\": \"Budget/purchasing authority\",\n",
+        "    \"team_size\": {\"description\": \"Size of team managed\", \"type\": \"int\"},\n",
+        "    \"recent_funding\": \"Recent funding news\",\n",
+        "    \"pain_points\": \"Known business challenges\",\n",
+        "    \"best_contact_time\": \"Best time to contact\"\n",
+        "}\n",
+        "\n",
+        "# Recruiting\n",
+        "example_recruiting_struct = {\n",
+        "    \"full_name\": \"Full name\",\n",
+        "    \"current_title\": \"Current job title\",\n",
+        "    \"years_experience\": {\"description\": \"Total years\", \"type\": \"int\"},\n",
+        "    \"technical_skills\": {\"description\": \"Technical skills\", \"type\": \"list[string]\"},\n",
+        "    \"previous_companies\": {\"description\": \"Previous employers\", \"type\": \"list[string]\"},\n",
+        "    \"education\": \"Highest degree\",\n",
+        "    \"open_to_opportunities\": {\"description\": \"Open to new roles\", \"type\": \"boolean\"},\n",
+        "    \"salary_expectations\": \"Expected salary range\"\n",
+        "}\n",
+        "\n",
+        "# Marketing\n",
+        "example_marketing_struct = {\n",
+        "    \"full_name\": \"Full name\",\n",
+        "    \"title\": \"Job title\",\n",
+        "    \"company_size\": \"Company size (employees)\",\n",
+        "    \"budget_authority\": {\"description\": \"Has budget authority\", \"type\": \"boolean\"},\n",
+        "    \"content_topics\": {\"description\": \"Topics they post about\", \"type\": \"list[string]\"},\n",
+        "    \"social_influence\": \"Social media influence level\",\n",
+        "    \"purchase_timeline\": \"Typical purchase timeline\",\n",
+        "    \"preferred_channels\": \"Preferred communication channels\"\n",
+        "}\n",
+        "\n",
+        "\n",
+        "# Business Development / Partnerships\n",
+        "example_bd_struct = {\n",
+        "    \"full_name\": \"Full name\",\n",
+        "    \"title\": \"Role/title\",\n",
+        "    \"decision_authority\": \"Partnership decision authority\",\n",
+        "    \"strategic_initiatives\": {\"description\": \"Key initiatives they own\", \"type\": \"list[string]\"},\n",
+        "    \"past_partnerships\": {\"description\": \"Notable past partnerships\", \"type\": \"list[string]\"},\n",
+        "    \"regions\": {\"description\": \"Regions covered\", \"type\": \"list[string]\"},\n",
+        "    \"best_contact_time\": \"Best time to contact\"\n",
+        "}\n",
+        "\n",
+        "# Investor / VC Outreach\n",
+        "example_investor_struct = {\n",
+        "    \"full_name\": \"Full name\",\n",
+        "    \"focus_sectors\": {\"description\": \"Sectors of interest\", \"type\": \"list[string]\"},\n",
+        "    \"stage_focus\": \"Stages (pre-seed/seed/A/B/...)\",\n",
+        "    \"check_size\": \"Typical check size\",\n",
+        "    \"notable_investments\": {\"description\": \"Notable investments\", \"type\": \"list[string]\"},\n",
+        "    \"recent_funds\": \"Recent fund announcements\",\n",
+        "    \"location\": \"Location\"\n",
+        "}\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "926347e1",
+      "metadata": {
+        "id": "926347e1"
+      },
+      "source": [
+        "\n",
+        "## Troubleshooting & Next steps\n",
+        "\n",
+        "**Remember:**  \n",
+        "- You can request up to 100 fields in one `struct`  \n",
+        "- Adding more fields doesn't increase API usage  \n",
+        "- Rate limit: **500 requests per minute** per API key  \n",
+        "- Don't be vague — “Saarth” vs “Saarth Shah, CEO at Sixtyfour AI”  \n",
+        "- Provide context — More details = better results  \n",
+        "\n",
+        "\n",
+        "**If a request fails:** make sure you provide either `email`, `linkedin`, or `(name AND company)`.  \n",
+        "If fields are missing, request fewer first or add more context to `lead_info`. For large workloads, prefer async or the concurrent batch.\n",
+        "\n",
+        "**Next steps:** try a different `struct`, point the CSV output to your CRM, or move this into an automated script.\n",
+        "\n",
+        "---\n",
+        "\n",
+        "*This notebook stays simple on purpose: small cells, clear comments, and the same pattern repeated so anyone can follow.*\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "Y4E7-uOXMqqG"
+      },
+      "id": "Y4E7-uOXMqqG",
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/sixtyfour_find_email_tutorial.ipynb
+++ b/sixtyfour_find_email_tutorial.ipynb
@@ -1,0 +1,233 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "9f4c23e2",
+      "metadata": {
+        "id": "9f4c23e2"
+      },
+      "source": [
+        "\n",
+        "# SixtyFour AI — Find Email\n",
+        "\n",
+        "This notebook is your guide to using the Sixtyfour API `find-email`.\n",
+        "\n",
+        "The `find-email` endpoint finds an email address for a lead based on the information you provide. It searches relevant sources and can validate deliverability. You can optionally restrict results to **company domains** and control whether to use **bruteforce** heuristics.\n",
+        "\n",
+        "**Tip:** You can change the lead in the parameters at the top. For best results, include the **name** and **company** (and optionally a strong identifier such as **LinkedIn**).\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "fc28d74f",
+      "metadata": {
+        "id": "fc28d74f"
+      },
+      "source": [
+        "\n",
+        "## Prerequisites & Secrets\n",
+        "\n",
+        "### Get your SixtyFour API key\n",
+        "1) Sign in: https://app.sixtyfour.ai/login and get your $25 in credits\n",
+        "2) Create an organization → **Keys** → **Create new key** → Copy the key.\n",
+        "\n",
+        "### If you’re in Google Colab\n",
+        "- Click the 🔑 (Secrets) icon in the left sidebar.  \n",
+        "- Add `SIXTYFOUR_API_KEY` and paste your key.  \n",
+        "- Make sure the notebook can access the secret.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "55f90c19",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "55f90c19",
+        "outputId": "0dcd2ff8-75d2-4313-9944-74ced3805e12"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ Setup complete (key detected, endpoint ready).\n"
+          ]
+        }
+      ],
+      "source": [
+        "\n",
+        "# --- Parameters (you can change these) ---\n",
+        "LEAD_NAME = \"Saarth Shah\"\n",
+        "LEAD_COMPANY = \"Sixtyfour AI\"\n",
+        "# Fill as needed below. The more context, the better it performs.\n",
+        "# LEAD_TITLE = \"CEO\"\n",
+        "# LEAD_LINKEDIN = \"https://www.linkedin.com/in/sarah-chen-photography\"\n",
+        "\n",
+        "BRUTEFORCE = False              # If True, tries common patterns + validation\n",
+        "ONLY_COMPANY_EMAILS = True      # If True, filters out personal emails (gmail, yahoo, etc.)\n",
+        "\n",
+        "import os, json, requests\n",
+        "\n",
+        "API_KEY = os.getenv(\"SIXTYFOUR_API_KEY\", \"\")\n",
+        "try:\n",
+        "    from google.colab import userdata\n",
+        "    secret_val = userdata.get(\"SIXTYFOUR_API_KEY\")\n",
+        "    if secret_val:\n",
+        "        os.environ[\"SIXTYFOUR_API_KEY\"] = secret_val\n",
+        "        API_KEY = secret_val\n",
+        "except Exception:\n",
+        "    pass\n",
+        "\n",
+        "BASE_URL = \"https://api.sixtyfour.ai\"\n",
+        "ENDPOINT = f\"{BASE_URL}/find-email\"\n",
+        "TIMEOUT_S = 180\n",
+        "\n",
+        "print(\"✅ Setup complete (key detected, endpoint ready).\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "45679055",
+      "metadata": {
+        "id": "45679055"
+      },
+      "source": [
+        "\n",
+        "## Find_Email Request\n",
+        "\n",
+        "For most use cases, `find-email` is the perfect tool. You send a request and get an email back with a single call.\n",
+        "\n",
+        "The request body requires:\n",
+        "\n",
+        "- **lead**: Lead information (name/company recommended; LinkedIn/domain/email if available).\n",
+        "\n",
+        "**Optional fields:**\n",
+        "\n",
+        "- **bruteforce (bool)**: Whether to try common patterns and validate.\n",
+        "- **only_company_emails (bool)**: If `true`, only company-domain emails are returned.\n",
+        "\n",
+        "Responses may take a moment depending on validation steps.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "738769bf",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "738769bf",
+        "outputId": "fd088da8-8fe2-441f-8687-ba5171c20ee2"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ Success! Keys: ['name', 'company', 'email']\n",
+            "\n",
+            "Response:\n",
+            "{\n",
+            "  \"name\": \"Saarth Shah\",\n",
+            "  \"company\": \"Sixtyfour AI\",\n",
+            "  \"email\": [\n",
+            "    [\n",
+            "      \"saarth@sixtyfour.ai\",\n",
+            "      \"UNKNOWN\",\n",
+            "      \"COMPANY\"\n",
+            "    ]\n",
+            "  ]\n",
+            "}\n",
+            "\n",
+            "Parsed emails:\n",
+            " - saarth@sixtyfour.ai | status=UNKNOWN | type=COMPANY\n"
+          ]
+        }
+      ],
+      "source": [
+        "\n",
+        "lead = {\n",
+        "    \"name\": LEAD_NAME,\n",
+        "    \"company\": LEAD_COMPANY,\n",
+        "    # \"title\": LEAD_TITLE,\n",
+        "    # \"linkedin\": LEAD_LINKEDIN,\n",
+        "}\n",
+        "\n",
+        "payload = {\n",
+        "    \"lead\": lead,\n",
+        "    \"bruteforce\": BRUTEFORCE,\n",
+        "    \"only_company_emails\": ONLY_COMPANY_EMAILS,\n",
+        "}\n",
+        "\n",
+        "resp = requests.post(\n",
+        "    ENDPOINT,\n",
+        "    headers={\"x-api-key\": API_KEY, \"Content-Type\": \"application/json\"},\n",
+        "    json=payload,\n",
+        "    timeout=TIMEOUT_S,\n",
+        ")\n",
+        "\n",
+        "if resp.ok:\n",
+        "    data = resp.json()\n",
+        "    print(\"✅ Success! Keys:\", list(data.keys()))\n",
+        "    print(\"\\nResponse:\")\n",
+        "    print(json.dumps(data, indent=2))\n",
+        "    # Email field is a list of tuples: [ [email, status, type], ... ]\n",
+        "    emails = data.get(\"email\", [])\n",
+        "    print(\"\\nParsed emails:\")\n",
+        "    for item in emails:\n",
+        "        try:\n",
+        "            addr, status, kind = item\n",
+        "            print(f\" - {addr} | status={status} | type={kind}\")\n",
+        "        except Exception:\n",
+        "            print(\" -\", item)\n",
+        "else:\n",
+        "    print(\"❌ Request failed:\", resp.status_code, resp.text[:800])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "00341f7f",
+      "metadata": {
+        "id": "00341f7f"
+      },
+      "source": [
+        "\n",
+        "### How to change values\n",
+        "\n",
+        "- Edit the lead fields at the top (name/company/title/LinkedIn).  \n",
+        "- Toggle `BRUTEFORCE` to try common patterns + validation.  \n",
+        "- Toggle `ONLY_COMPANY_EMAILS` to restrict to company-domain addresses.  \n",
+        "- If `lead` already includes an `email`, the API returns it unchanged (status `\"OK\"`).\n",
+        "- Provide context — More details = better results\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "Za0b1a58RGv7"
+      },
+      "id": "Za0b1a58RGv7",
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/sixtyfour_find_phone_tutorial.ipynb
+++ b/sixtyfour_find_phone_tutorial.ipynb
@@ -1,0 +1,212 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "d02817c4",
+      "metadata": {
+        "id": "d02817c4"
+      },
+      "source": [
+        "\n",
+        "# SixtyFour AI — Find Phone (Beta)\n",
+        "\n",
+        "This notebook is your guide to using the Sixtyfour API `find-phone` (beta).\n",
+        "\n",
+        "The `find-phone` endpoint discovers phone numbers for a lead from the data you provide. It looks across relevant sources and returns a phone number as a string or an array of phone objects (number + region).\n",
+        "\n",
+        "**Tip:** You can change the lead in the parameters at the top. Include **name**, **company**, and a strong identifier (e.g., **LinkedIn**, **domain**, or **email**) for best results.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "60b45fff",
+      "metadata": {
+        "id": "60b45fff"
+      },
+      "source": [
+        "\n",
+        "## Prerequisites & Secrets\n",
+        "\n",
+        "### Get your SixtyFour API key\n",
+        "1) Sign in: https://app.sixtyfour.ai/login  \n",
+        "2) Create an organization → **Keys** → **Create new key** → Copy the key.\n",
+        "\n",
+        "### If you’re in Google Colab\n",
+        "- Click the 🔑 (Secrets) icon in the left sidebar.  \n",
+        "- Add `SIXTYFOUR_API_KEY` and paste your key.  \n",
+        "- Make sure the notebook can access the secret.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "be9bf79c",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "be9bf79c",
+        "outputId": "e1d014aa-6196-4fb9-9a4a-d679e0226273"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ Setup complete (key detected, endpoint ready).\n"
+          ]
+        }
+      ],
+      "source": [
+        "\n",
+        "# --- Parameters (you can change these) ---\n",
+        "LEAD_NAME = \"Saarth Shah\"\n",
+        "LEAD_COMPANY = \"Sixtyfour AI\"\n",
+        "# LEAD_LINKEDIN = \"https://linkedin.com/in/sarahjohnson\"\n",
+        "# LEAD_DOMAIN = None\n",
+        "# LEAD_EMAIL = None\n",
+        "\n",
+        "import os, json, requests\n",
+        "\n",
+        "API_KEY = os.getenv(\"SIXTYFOUR_API_KEY\", \"\")\n",
+        "try:\n",
+        "    from google.colab import userdata\n",
+        "    secret_val = userdata.get(\"SIXTYFOUR_API_KEY\")\n",
+        "    if secret_val:\n",
+        "        os.environ[\"SIXTYFOUR_API_KEY\"] = secret_val\n",
+        "        API_KEY = secret_val\n",
+        "except Exception:\n",
+        "    pass\n",
+        "\n",
+        "BASE_URL = \"https://api.sixtyfour.ai\"\n",
+        "ENDPOINT = f\"{BASE_URL}/find-phone\"\n",
+        "TIMEOUT_S = 180\n",
+        "\n",
+        "print(\"✅ Setup complete (key detected, endpoint ready).\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "606b830d",
+      "metadata": {
+        "id": "606b830d"
+      },
+      "source": [
+        "\n",
+        "## Find_Phone Request\n",
+        "\n",
+        "For most use cases, `find-phone` is straightforward: pass a `lead` object and receive a phone value in return.\n",
+        "\n",
+        "The request body requires:\n",
+        "\n",
+        "- **lead (object)**: Lead information (name/company recommended; LinkedIn/domain/email help).\n",
+        "\n",
+        "Responses may return:\n",
+        "- **String**: `\"+1 555-123-4567\"`  \n",
+        "- **Array of objects**: `[{\"number\": \"+1 555-123-4567\", \"region\": \"US\"}, ...]`  \n",
+        "- **Empty string**: `\"\"` when no phone is found.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "c7992f64",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "c7992f64",
+        "outputId": "1e270153-9c7f-402e-912e-2f3d75550ce2"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ Success! Keys: ['name', 'company', 'phone']\n",
+            "\n",
+            "Raw response:\n",
+            "{\n",
+            "  \"name\": \"Saarth Shah\",\n",
+            "  \"company\": \"Sixtyfour AI\",\n",
+            "  \"phone\": \"+1 502-388-0975\"\n",
+            "}\n",
+            "\n",
+            "Parsed phone(s):\n",
+            " - +1 502-388-0975\n"
+          ]
+        }
+      ],
+      "source": [
+        "\n",
+        "lead = {\n",
+        "    \"name\": LEAD_NAME,\n",
+        "    \"company\": LEAD_COMPANY,\n",
+        "}\n",
+        "# if LEAD_LINKEDIN: lead[\"linkedin_url\"] = LEAD_LINKEDIN\n",
+        "# if LEAD_DOMAIN: lead[\"domain\"] = LEAD_DOMAIN\n",
+        "# if LEAD_EMAIL: lead[\"email\"] = LEAD_EMAIL\n",
+        "\n",
+        "payload = {\"lead\": lead}\n",
+        "\n",
+        "resp = requests.post(\n",
+        "    ENDPOINT,\n",
+        "    headers={\"x-api-key\": API_KEY, \"Content-Type\": \"application/json\"},\n",
+        "    json=payload,\n",
+        "    timeout=TIMEOUT_S,\n",
+        ")\n",
+        "\n",
+        "if resp.ok:\n",
+        "    data = resp.json()\n",
+        "    print(\"✅ Success! Keys:\", list(data.keys()))\n",
+        "    print(\"\\nRaw response:\")\n",
+        "    print(json.dumps(data, indent=2))\n",
+        "\n",
+        "    # Handle string vs array formats\n",
+        "    phone_val = data.get(\"phone\", \"\")\n",
+        "    print(\"\\nParsed phone(s):\")\n",
+        "    if isinstance(phone_val, str):\n",
+        "        print(\" -\", phone_val or \"Not found\")\n",
+        "    elif isinstance(phone_val, list):\n",
+        "        for p in phone_val:\n",
+        "            if isinstance(p, dict):\n",
+        "                print(f\" - {p.get('number')} (region={p.get('region')})\")\n",
+        "            else:\n",
+        "                print(\" -\", p)\n",
+        "    else:\n",
+        "        print(\" - Not found\")\n",
+        "else:\n",
+        "    print(\"❌ Request failed:\", resp.status_code, resp.text[:800])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "99b44319",
+      "metadata": {
+        "id": "99b44319"
+      },
+      "source": [
+        "\n",
+        "### How to change values\n",
+        "\n",
+        "- Edit the lead fields (name/company/LinkedIn/domain/email).  \n",
+        "- If you have multiple identifiers, include them—more context improves accuracy.  \n",
+        "- Expect `phone` to be a **string**, an **array of objects**, or an **empty string**.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/sixtyfour_qa_agent_tutorial.ipynb
+++ b/sixtyfour_qa_agent_tutorial.ipynb
@@ -1,0 +1,273 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "eb0d6cf5",
+      "metadata": {
+        "id": "eb0d6cf5"
+      },
+      "source": [
+        "\n",
+        "# SixtyFour AI — QA Agent (Beta)\n",
+        "\n",
+        "This notebook is your guide to using the Sixtyfour API `qa-agent` (beta).\n",
+        "\n",
+        "The `qa-agent` endpoint evaluates and qualifies data against predefined criteria using autonomous research and structured analysis. It can read your provided data, perform targeted research (optionally using your references), score against your criteria, and return a clean `structured_data` block plus notes.\n",
+        "\n",
+        "**Tip:** You can change the `data` object and criteria at the top. Make criteria **clear and weighted** for best results.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0af7cd43",
+      "metadata": {
+        "id": "0af7cd43"
+      },
+      "source": [
+        "\n",
+        "## Prerequisites & Secrets\n",
+        "\n",
+        "### Get your SixtyFour API key\n",
+        "1) Sign in: https://app.sixtyfour.ai/login  \n",
+        "2) Create an organization → **Keys** → **Create new key** → Copy the key.\n",
+        "\n",
+        "### If you’re in Google Colab\n",
+        "- Click the 🔑 (Secrets) icon in the left sidebar.  \n",
+        "- Add `SIXTYFOUR_API_KEY` and paste your key.  \n",
+        "- Make sure the notebook can access the secret.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "7bbf98cc",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7bbf98cc",
+        "outputId": "140c7131-0164-4640-aa22-ac68b6dca3e9"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ Setup complete (key detected, endpoint ready).\n"
+          ]
+        }
+      ],
+      "source": [
+        "\n",
+        "# --- Parameters (you can change these) ---\n",
+        "DATA_NAME = \"Saarth Shah\"\n",
+        "DATA_BUSINESS_TYPE = \"Bakery\"\n",
+        "DATA_FOLLOWERS = \"1 million\"\n",
+        "DATA_TWITTER = \"saarth_\"\n",
+        "DATA_POSTS = \"6500\"\n",
+        "\n",
+        "import os, json, requests\n",
+        "\n",
+        "API_KEY = os.getenv(\"SIXTYFOUR_API_KEY\", \"\")\n",
+        "try:\n",
+        "    from google.colab import userdata\n",
+        "    secret_val = userdata.get(\"SIXTYFOUR_API_KEY\")\n",
+        "    if secret_val:\n",
+        "        os.environ[\"SIXTYFOUR_API_KEY\"] = secret_val\n",
+        "        API_KEY = secret_val\n",
+        "except Exception:\n",
+        "    pass\n",
+        "\n",
+        "BASE_URL = \"https://api.sixtyfour.ai\"\n",
+        "ENDPOINT = f\"{BASE_URL}/qa-agent\"\n",
+        "TIMEOUT_S = 600\n",
+        "\n",
+        "print(\"✅ Setup complete (key detected, endpoint ready).\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5eccf823",
+      "metadata": {
+        "id": "5eccf823"
+      },
+      "source": [
+        "\n",
+        "## QA_Agent Request\n",
+        "\n",
+        "For most use cases, `qa-agent` is simple: pass a `data` object, a list of `qualification_criteria`, and (optionally) `references` and `struct`.\n",
+        "\n",
+        "The request body requires:\n",
+        "- **data (object)**: Primary data to evaluate and research.\n",
+        "- **qualification_criteria (array)**: List of criteria with names, descriptions, weights, and optional thresholds.\n",
+        "\n",
+        "**Optional fields:**\n",
+        "- **references (array)**: URLs to guide research (LinkedIn, Instagram, websites).  \n",
+        "- **struct (object)**: Output fields to include in `structured_data` (names + descriptions).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "7dcc27c4",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7dcc27c4",
+        "outputId": "61cabef6-244a-4018-ae7b-85395f28c500"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ Success! Keys: ['structured_data', 'notes']\n",
+            "\n",
+            "Structured data:\n",
+            "{\n",
+            "  \"recommendation\": \"REJECT due to follower count below required threshold and insufficient evidence of bakery business in San Francisco\",\n",
+            "  \"final_verdict\": \"NO\",\n",
+            "  \"disqualification_reason\": \"Follower count below minimum requirement of 2,500; no verified bakery business presence in San Francisco\",\n",
+            "  \"suitability_score\": \"3\"\n",
+            "}\n",
+            "\n",
+            "Notes:\n",
+            "Research findings indicate that Saarth Shah is primarily a tech entrepreneur and software engineer based in San Francisco, involved with a company named Sixtyfour, not explicitly a bakery owner. The Twitter profile (https://www.x.com/saarth_) shows about 2,640 followers, barely above the 2,500 threshold, but the original data claiming 1 million followers and post count '6500' is inconsistent and unverified. No official bakery website or social media presence related to a bakery business was found despite multiple targeted searches and attempts to scrape potential bakery sites, including https://www.saarthshahbakery.com which returned errors. LinkedIn profiles indicate location in San Francisco but reflect tech industry affiliations, not bakery industry. No Instagram or other social media profiles related to a bakery business in San Francisco were identified. The qualification criteria require at least 2,500 followers and confirmed San Francisco bakery location. Although the Twitter follower count meets the follower minimum marginally, the lack of evidence supporting the bakery business location and type disqualifies the subject. Data quality is mixed, with contradictory original input (followers count and Twitter handle) and insufficient corroborating evidence from research results and scraping attempts. Given these factors, a conservative suitability score of 3 (low fit) is assigned. Recommendation is REJECT due to failure to meet the primary qualification criterion of verified bakery business in San Francisco and uncertainty around follower data related to bakery branding.\n"
+          ]
+        }
+      ],
+      "source": [
+        "data_obj = {\n",
+        "    \"name\": DATA_NAME,\n",
+        "    \"business_type\": DATA_BUSINESS_TYPE,\n",
+        "    \"follower_count\": DATA_FOLLOWERS,\n",
+        "    \"post_count\": DATA_POSTS,\n",
+        "    \"twitter_handle\": DATA_POSTS,\n",
+        "}\n",
+        "\n",
+        "criteria = [\n",
+        "    {\n",
+        "        \"criteria_name\": \"Follower count\",\n",
+        "        \"description\": \"Must have at least 2,500 followers\",\n",
+        "        \"weight\": 10.0,\n",
+        "        \"threshold\": 8.0\n",
+        "    },\n",
+        "    {\n",
+        "        \"criteria_name\": \"Target Market Location\",\n",
+        "        \"description\": \"Must be located in San Francisco\",\n",
+        "        \"weight\": 8.0\n",
+        "    }\n",
+        "]\n",
+        "\n",
+        "references = [\n",
+        "    {\"url\": f\"https://www.x.com/{DATA_TWITTER}\", \"description\": \"Twitter profile\"}\n",
+        "]\n",
+        "\n",
+        "# You may optionally specify types for predictable outputs inside struct fields (e.g., {\"type\": \"int\"}).\n",
+        "struct = {\n",
+        "    \"suitability_score\": \"Overall qualification score (0-10)\",\n",
+        "    \"disqualification_reason\": \"Primary reason for disqualification if applicable\",\n",
+        "    \"final_verdict\": \"Clear YES/NO decision\",\n",
+        "    \"recommendation\": \"ACCEPT/REJECT with reasoning\"\n",
+        "}\n",
+        "\n",
+        "payload = {\n",
+        "    \"data\": data_obj,\n",
+        "    \"qualification_criteria\": criteria,\n",
+        "    \"references\": references,\n",
+        "    \"struct\": struct\n",
+        "}\n",
+        "\n",
+        "resp = requests.post(\n",
+        "    ENDPOINT,\n",
+        "    headers={\"x-api-key\": API_KEY, \"Content-Type\": \"application/json\"},\n",
+        "    json=payload,\n",
+        "    timeout=TIMEOUT_S,\n",
+        ")\n",
+        "\n",
+        "if resp.ok:\n",
+        "    result = resp.json()\n",
+        "    print(\"✅ Success! Keys:\", list(result.keys()))\n",
+        "    print(\"\\nStructured data:\")\n",
+        "    print(json.dumps(result.get(\"structured_data\", {}), indent=2))\n",
+        "    print(\"\\nNotes:\")\n",
+        "    print(result.get(\"notes\", \"\"))\n",
+        "else:\n",
+        "    print(\"❌ Request failed:\", resp.status_code, resp.text[:800])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d77947c3",
+      "metadata": {
+        "id": "d77947c3"
+      },
+      "source": [
+        "\n",
+        "### How to change values\n",
+        "\n",
+        "- Edit fields in `data_obj` for your candidate/business.  \n",
+        "- Adjust `criteria` names, descriptions, weights, and thresholds to match your rubric.  \n",
+        "- Add `references` (LinkedIn, Instagram, websites) to guide research.  \n",
+        "- Modify `struct` to control which fields appear in `structured_data`.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2f2b9120",
+      "metadata": {
+        "id": "2f2b9120"
+      },
+      "source": [
+        "\n",
+        "## Example criteria & struct (copy/paste)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "38040a9f",
+      "metadata": {
+        "id": "38040a9f"
+      },
+      "outputs": [],
+      "source": [
+        "\n",
+        "example_criteria_light = [\n",
+        "    {\"criteria_name\": \"Active Posting\", \"description\": \"Posts at least weekly\", \"weight\": 5.0},\n",
+        "    {\"criteria_name\": \"Audience Size\", \"description\": \"At least 1000 followers\", \"weight\": 3.0}\n",
+        "]\n",
+        "\n",
+        "example_criteria_strict = [\n",
+        "    {\"criteria_name\": \"Inventory Ownership\", \"description\": \"Owns and ships products directly\", \"weight\": 10.0, \"threshold\": 9.0},\n",
+        "    {\"criteria_name\": \"EU Location\", \"description\": \"Located in EU\", \"weight\": 6.0}\n",
+        "]\n",
+        "\n",
+        "example_struct_min = {\n",
+        "    \"suitability_score\": \"Overall score (0-10)\",\n",
+        "    \"final_verdict\": \"YES/NO decision\"\n",
+        "}\n",
+        "\n",
+        "print(\"Ready-to-use examples:\")\n",
+        "print(\"criteria (light):\", example_criteria_light)\n",
+        "print(\"criteria (strict):\", example_criteria_strict)\n",
+        "print(\"struct (minimal):\", example_struct_min)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

This PR replaces outdated notebooks with 5 new comprehensive tutorial notebooks and cleans up the repository structure.

## Changes Made

**Removed:**
- smb.ipynb
- enrich_emails.ipynb  
- enrich_leads.ipynb

**Added:**
- sixtyfour_enrich_company_tutorial.ipynb
- sixtyfour_enrich_lead_tutorial.ipynb  
- sixtyfour_find_email_tutorial.ipynb
- sixtyfour_find_phone_tutorial.ipynb
- sixtyfour_qa_agent_tutorial.ipynb

## Improvements

- Replaced outdated notebooks with comprehensive tutorials covering all major SixtyFour API endpoints
- Cleaned up filenames by removing version numbers for professional presentation
- Each notebook includes interactive examples and Colab integration

These notebooks provide developers with production-ready examples for integrating SixtyFour's API capabilities.